### PR TITLE
Set up GitHub Pages for documentation site

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -3,6 +3,9 @@ export default {
   description: 'TypeScript SDK for SoroSave - Decentralized Group Savings Protocol on Soroban',
   base: '/sdk/',
   themeConfig: {
+    search: {
+      provider: 'local'
+    },
     nav: [
       { text: 'Home', link: '/' },
       { text: 'Guide', link: '/guide/getting-started' },
@@ -38,7 +41,7 @@ export default {
     ],
     footer: {
       message: 'Released under the MIT License.',
-      copyright: 'Copyright © 2026 SoroSave Protocol'
+      copyright: 'Copyright 2026 SoroSave Protocol'
     }
   }
 }


### PR DESCRIPTION
## Changes

Implements #21 - deploys VitePress docs to GitHub Pages.

### 1. GitHub Actions workflow (`.github/workflows/docs.yml`)
- Triggers on push to `main` when `docs/` or workflow file changes
- Supports manual `workflow_dispatch` trigger
- Builds VitePress site and deploys to GitHub Pages
- Uses `actions/deploy-pages@v4` with proper permissions

### 2. VitePress search (`docs/.vitepress/config.mjs`)
- Enabled built-in local search via `themeConfig.search.provider: 'local'`

### Setup Required

After merging, the repo admin needs to:
1. Go to Settings > Pages
2. Set Source to `GitHub Actions`
3. The workflow will deploy automatically on next push to main

Fixes #21

---
Wallet: zp6